### PR TITLE
Changed `maybe`'s handling of an empty object

### DIFF
--- a/JavaScript/8-path.js
+++ b/JavaScript/8-path.js
@@ -13,7 +13,13 @@ fp.path = (data) => (
   )
 );
 
-fp.maybe = (x) => (fn) => fp.maybe(x && fn ? fn(x) : null);
+fp.isJust = (value) => {
+  if (!value || typeof value !== 'object') return Boolean(value);
+  if (Object.keys(value).length === 0) return false;
+  return true;
+};
+
+fp.maybe = (x) => (fn) => fp.maybe(fp.isJust(x) && fn ? fn(x) : null);
 
 // Usage
 


### PR DESCRIPTION
The current implementation throws an error if `config` doesn't have the key or the path is wrong:
```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string or an instance of Buffer or URL. Received an instance of Object
```

The reason is that an empty object passed from `fp.path` is regarded as a truthy value and `readFile` is called, while expected to be silently ommited.

Added `isJust` check to handle empty object cases.